### PR TITLE
Make variadic functions portable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .deps
 .dirstamp
 .gdb_history
+.vscode/
 GPATH
 GRTAGS
 GTAGS

--- a/src/echo.c
+++ b/src/echo.c
@@ -362,7 +362,6 @@ register SYMBOL	*sp2;
  * echo line. The formatting is done by a call
  * to the standard formatting routine.
  */
-/* VARARGS1 */
 void eprintf(char* fp, va_list ap)
 {
 	ttcolor(CTEXT);


### PR DESCRIPTION
The original source code assumed an x86-like cdecl calling convention, to handle variadic parameter functions. It assumed that the parameters were pushed sequentially onto the stack, and then iterated through the stack using pointer arithmetic. This breaks in spectactular ways where the calling convention allows passing parameters as registers (x86-64).

This patch makes the variadic functions portable, while trying to minimize the "damage" on the original sources.

References 
Segfault when quiting with a dirty buffer #3 