### PR TITLE
Windows port of uemacs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,16 @@
 *~
 *.o
+*.obj
+*.exe
 .deps
 .dirstamp
 .gdb_history
 .vscode/
+.vs/
+*.vcxproj.user
+src/sys/windows/Debug/
+src/sys/windows/Release/
+src/sys/windows/x64/
 GPATH
 GRTAGS
 GTAGS

--- a/build-win.cmd
+++ b/build-win.cmd
@@ -1,0 +1,43 @@
+@echo off
+
+REM Figure out the platform we're on, and use that as target platform
+REM If the user wants another platform, set environment variable PLATFORM
+REM to a desired value (x86, x64, ia64)
+if "%PLATFORM%" equ "" (
+    if "%PROCESSOR_ARCHITECTURE%" equ "x86" (
+        if "%PROCESSOR_ARCHITEW6432%" neq "" (
+            set PLATFORM=x64
+        ) else (
+            set PLATFORM=Win32
+        )
+    ) else (
+        set PLATFORM=x64
+    )
+)
+
+REM Assume the user wants Release (full optimization, no debug information)
+REM Override by setting the environment variable CONFIGURATION to one of
+REM Release or Debug.
+if "%CONFIGURATION%" equ "" (
+    set CONFIGURATION=Release
+)
+
+REM Check to make sure msbuild is available
+WHERE /q msbuild
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO msbuild not found on path. Try running this command in the Visual Studio developer command prompt.
+    exit /b 1
+)
+
+pushd src\sys\windows
+msbuild uemacs.vcxproj /p:Configuration=Release /p:Platfom=%PLATFORM% /p:OutDir=..\..\..\
+popd
+
+REM Check if the compilation failed
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO msbuild failed. Have you installed the Visual Studio C++ workload? Examine the msbuild output above for more information.
+    exit /b 1
+)
+
+REM Remove debug files the user isn't concerned with anyhow
+del /q uemacs.iobj uemacs.ipdb uemacs.pdb

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -196,7 +196,7 @@ makelist()
 			nbytes += llength(lp)+1;
 			lp = lforw(lp);
 		}
-		itoa(b, 6, nbytes);		/* 6 digit buffer size.	*/
+		itoa_(b, 6, nbytes);		/* 6 digit buffer size.	*/
 		cp2 = &b[0];
 		while ((c = *cp2++) != 0)
 			*cp1++ = c;
@@ -224,7 +224,7 @@ makelist()
 /*
  * Used above.
  */
-itoa(buf, width, num)
+itoa_(buf, width, num)
 register char	buf[];
 register int	width;
 register int	num;

--- a/src/sys/windows/config.h
+++ b/src/sys/windows/config.h
@@ -1,0 +1,6 @@
+/*
+ * config.h for Windows (no automake here!)
+ *
+ * Jörgen Sigvardsson <jorgen.sigvardsson@gmail.com>
+ */
+#define PACKAGE_VERSION "30-windows"

--- a/src/sys/windows/fileio.c
+++ b/src/sys/windows/fileio.c
@@ -1,0 +1,164 @@
+/*
+ * File I/O. Based on the original source code by Dave Conroy.
+ * 
+ * Jörgen Sigvardsson <jorgen.sigvardsson@gmail.com>
+ */
+#include	"def.h"
+
+static	FILE	*ffp;
+
+/*
+ * Open a file for reading.
+ */
+ffropen(fn)
+char	*fn;
+{
+	if ((ffp=fopen(fn, "r")) == NULL)
+		return (FIOFNF);
+	return (FIOSUC);
+}
+
+/*
+ * Open a file for writing.
+ * Return TRUE if all is well, and
+ * FALSE on error (cannot create).
+ */
+ffwopen(fn)
+char	*fn;
+{
+	if ((ffp=fopen(fn, "w")) == NULL) {
+		eprintf("Cannot open file for writing");
+		return (FIOERR);
+	}
+	return (FIOSUC);
+}
+
+/*
+ * Close a file.
+ * Should look at the status.
+ */
+ffclose()
+{
+	fclose(ffp);
+	return (FIOSUC);
+}
+
+/*
+ * Write a line to the already
+ * opened file. The "buf" points to the
+ * buffer, and the "nbuf" is its length, less
+ * the free newline. Return the status.
+ * Check only at the newline.
+ */
+ffputline(buf, nbuf)
+register char	buf[];
+{
+	register int	i;
+
+	for (i=0; i<nbuf; ++i)
+		putc(buf[i]&0xFF, ffp);
+	putc('\n', ffp);
+	if (ferror(ffp) != FALSE) {
+		eprintf("Write I/O error");
+		return (FIOERR);
+	}
+	return (FIOSUC);
+}
+
+/*
+ * Read a line from a file, and store the bytes
+ * in the supplied buffer. Stop on end of file or end of
+ * line. Don't get upset by files that don't have an end of
+ * line on the last line; this seem to be common on CP/M-86 and
+ * MS-DOS (the suspected culprit is VAX/VMS kermit, but this
+ * has not been confirmed. If this is sufficiently researched
+ * it may be possible to pull this kludge). Delete any CR
+ * followed by an LF. This is mainly for runoff documents,
+ * both on VMS and on Ultrix (they get copied over from
+ * VMS systems with DECnet).
+ */
+ffgetline(buf, nbuf)
+register char	buf[];
+{
+	register int	c;
+	register int	i;
+
+	i = 0;
+	for (;;) {
+		c = getc(ffp);
+		if (c == '\r') {		/* Delete any non-stray	*/
+			c = getc(ffp);		/* carriage returns.	*/
+			if (c != '\n') {
+				if (i >= nbuf-1) {
+					eprintf("File has long line");
+					return (FIOERR);
+				}
+				buf[i++] = '\r';
+			}
+		}
+		if (c==EOF || c=='\n')		/* End of line.		*/
+			break;
+		if (i >= nbuf-1) {
+			eprintf("File has long line");
+			return (FIOERR);
+		}
+		buf[i++] = c;
+	}
+	if (c == EOF) {				/* End of file.		*/
+		if (ferror(ffp) != FALSE) {
+			eprintf("File read error");
+			return (FIOERR);
+		}
+		if (i == 0)			/* Don't get upset if	*/
+			return (FIOEOF);	/* no newline at EOF.	*/
+	}
+	buf[i] = 0;
+	return (FIOSUC);
+}
+
+/*
+ * Rename the file "fname" into a backup
+ * copy. On Unix the backup has the same name as the
+ * original file, with a "~" on the end; this seems to
+ * be newest of the new-speak. The error handling is
+ * all in "file.c". The "unlink" is perhaps not the
+ * right thing here; I don't care that much as
+ * I don't enable backups myself.
+ */
+fbackupfile(fname)
+char	*fname;
+{
+	register char	*nname;
+
+	if ((nname=malloc(strlen(fname)+1+1)) == NULL)
+		return (ABORT);
+	(void) strcpy(nname, fname);
+	(void) strcat(nname, "~");
+	(void) unlink(nname);			/* Ignore errors.	*/
+	if (rename(fname, nname) < 0) {
+		free(nname);
+		return (FALSE);
+	}
+	free(nname);
+	return (TRUE);
+}
+
+/*
+ * The string "fn" is a file name.
+ * Perform any required case adjustments. All sustems
+ * we deal with so far have case insensitive file systems.
+ * We zap everything to lower case. The problem we are trying
+ * to solve is getting 2 buffers holding the same file if
+ * you visit one of them with the "caps lock" key down.
+ */
+adjustcase(fn)
+register char	*fn;
+{
+	register int	c;
+
+	while ((c = *fn) != 0) {
+		if (c>='A' && c<='Z')
+			*fn = c + 'a' - 'A';
+		++fn;
+	}
+}

--- a/src/sys/windows/spawn.c
+++ b/src/sys/windows/spawn.c
@@ -1,0 +1,77 @@
+/*
+ * Spawn shell functionality for Windows.
+ * 
+ * Jörgen Sigvardsson <jorgen.sigvardsson@gmail.com>
+ */
+#include <Windows.h>
+#include "def.h"
+
+/*
+ * This code does a one of 2 different
+ * things, depending on what version of the shell
+ * you are using. If you are using the C shell, which
+ * implies that you are using job control, then MicroEMACS
+ * moves the cursor to a nice place and sends itself a
+ * stop signal. If you are using the Bourne shell it runs
+ * a subshell using fork/exec. Bound to "C-C", and used
+ * as a subcommand by "C-Z".
+ */
+spawncli(f, n, k)
+{
+	DWORD old_input_mode;
+	DWORD old_output_mode;
+	STARTUPINFOA si = {0};
+	PROCESS_INFORMATION pi = {0};
+	char* shell;
+	
+	si.cb = sizeof(si);
+
+	/* Close down the current terminal mode */
+	ttcolor(CTEXT);
+	ttnowindow();
+	ttflush();
+	ttclose();
+
+	/* Now the terminal is back into the same mode as prior to starting uemacs */
+
+	/* Figure out what shell to execute */
+	if (getenv("UEMACS_SHELL")) {
+		/* If the user has set UEMACS_SHELL, then use it */
+		shell = getenv("UEMACS_SHELL");
+	} else if(getenv("ComSpec")) {
+		/* If not, then use the regular shell */
+		shell = getenv("ComSpec");
+	} else {
+		/* last resort! */
+		shell = "cmd.exe";
+	}
+
+	/* Start the child process. */
+	if (!CreateProcessA(
+		NULL,           /* No module name (use command line) */
+		shell,          /* The selected shell*/
+		NULL,           /* Process handle not inheritable */
+		NULL,           /* Thread handle not inheritable */
+		FALSE,          /* Set handle inheritance to FALSE */
+		0,              /* No creation flags */
+		NULL,           /* Use parent's environment block */
+		NULL,           /* Use parent's starting directory */
+		&si,            /* Pointer to STARTUPINFO structure */
+		&pi)            /* Pointer to PROCESS_INFORMATION structure */
+		) {
+		eprintf("Failed to create process");
+		return FALSE;
+	}
+
+	/* Wait until child process exits. */
+	WaitForSingleObject(pi.hProcess, INFINITE);
+
+	/* Close process and thread handles. */
+	CloseHandle(pi.hProcess);
+	CloseHandle(pi.hThread);
+
+	sgarbf = TRUE;				/* Force repaint.	*/
+	ttopen();
+
+	return TRUE;
+}

--- a/src/sys/windows/sysdef.h
+++ b/src/sys/windows/sysdef.h
@@ -1,0 +1,18 @@
+/*
+ * Windows specific definitions.
+ *
+ * Jörgen Sigvardsson <jorgen.sigvardsson@gmail.com>
+ */
+#define	PCC	1			/* "[]" gets an error.		*/
+#define	KBLOCK	8192			/* Kill grow.			*/
+#define	GOOD	0			/* Good exit status.		*/
+
+/*
+ * Macros used by the buffer name making code.
+ * Start at the end of the file name, scan to the left
+ * until BDC1 (or BDC2, if defined) is reached. The buffer
+ * name starts just to the right of that location, and
+ * stops at end of string (or at the next BDC3 character,
+ * if defined). BDC2 and BDC3 are mainly for VMS.
+ */
+#define	BDC1	'/'			/* Buffer names.		*/

--- a/src/sys/windows/ttyio.c
+++ b/src/sys/windows/ttyio.c
@@ -1,0 +1,137 @@
+/*
+ * Windows terminal I/O. Based heavily on sys/unix/ttyio.c.
+ * 
+ * Jörgen Sigvardsson <jorgen.sigvardsson@gmail.com>
+ */
+#include    <Windows.h>
+#include    <wincon.h>
+#include	"def.h"
+
+static char* obuf = NULL;
+static int	nobuf;
+int	nrow = NROW;				/* Terminal size, rows.		*/
+int	ncol = NCOL;				/* Terminal size, columns.	*/
+#define BUFLEN (nrow * ncol)
+#define CSI "\x1b["
+
+static DWORD old_output_mode;
+static DWORD old_input_mode;
+static CONSOLE_SCREEN_BUFFER_INFOEX oldtty;
+static HANDLE consoleOutputHandle = INVALID_HANDLE_VALUE;
+static HANDLE consoleInputHandle = INVALID_HANDLE_VALUE;
+
+/*
+ * This function gets called once, to set up
+ * the terminal channel. On Ultrix is's tricky, since
+ * we want flow control, but we don't want any characters
+ * stolen to send signals. Use CBREAK mode, and set all
+ * characters but start and stop to 0xFF.
+ */
+void ttopen()
+{
+    DWORD new_input_mode;
+    DWORD new_output_mode;
+    CONSOLE_SCREEN_BUFFER_INFOEX newtty;
+
+	/* Open alternate screen buffer */
+    printf(CSI "?1049h");
+	
+    consoleOutputHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+    consoleInputHandle = GetStdHandle(STD_INPUT_HANDLE);
+    if (consoleOutputHandle == INVALID_HANDLE_VALUE || consoleInputHandle == INVALID_HANDLE_VALUE)
+        abort();
+
+    if (!GetConsoleMode(consoleOutputHandle, &old_output_mode))
+        abort();
+
+    if (!GetConsoleMode(consoleInputHandle, &old_input_mode))
+        abort();
+
+    oldtty.cbSize = sizeof(oldtty);
+    if (!GetConsoleScreenBufferInfoEx(consoleOutputHandle, &oldtty))
+        abort();
+
+    newtty = oldtty;
+    newtty.dwSize.X = NCOL;
+    newtty.dwSize.Y = NROW;
+    newtty.srWindow.Top = 0;
+    newtty.srWindow.Left = 0;
+    newtty.srWindow.Bottom = NROW;
+    newtty.srWindow.Right = NCOL;
+    newtty.dwMaximumWindowSize.X = NCOL;
+    newtty.dwMaximumWindowSize.Y = NROW;
+
+    if (!SetConsoleScreenBufferInfoEx(consoleOutputHandle, &newtty))
+        abort();
+
+	new_input_mode = ENABLE_VIRTUAL_TERMINAL_INPUT;
+    new_output_mode = old_output_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+
+    if (!SetConsoleMode(consoleOutputHandle, new_output_mode))
+        abort();
+
+    if (!SetConsoleMode(consoleInputHandle, new_input_mode))
+        abort();
+
+    obuf = malloc(BUFLEN);
+}
+
+/*
+ * This function gets called just
+ * before we go back home to the shell. Put all of
+ * the terminal parameters back.
+ */
+void ttclose()
+{
+    if (consoleOutputHandle != INVALID_HANDLE_VALUE) {
+        SetConsoleScreenBufferInfoEx(consoleOutputHandle, &oldtty);
+    	
+        /* Exit the alternate buffer */
+        printf(CSI "?1049l");
+
+        SetConsoleMode(consoleOutputHandle, old_output_mode);
+        SetConsoleMode(consoleInputHandle, old_input_mode);
+        free(obuf);
+    }	
+}
+
+/*
+ * Flush output.
+ */
+void ttflush()
+{
+    if (nobuf != 0) {
+        WriteConsoleA(consoleOutputHandle, obuf, nobuf, NULL, NULL);
+        nobuf = 0;
+    }
+}
+
+
+/*
+ * Write character to the display.
+ * Characters are buffered up, to make things
+ * a little bit more efficient.
+ */
+void ttputc(char c) {
+    if (nobuf >= BUFLEN)
+        ttflush();
+    obuf[nobuf++] = c;
+}
+
+/*
+ * Read character from terminal.
+ * All 8 bits are returned, so that you can use
+ * a multi-national terminal.
+ */
+char ttgetc()
+{
+    INPUT_RECORD input;
+    DWORD numEventsRead;
+
+    for (;;) {
+	    if (!ReadConsoleInput(consoleInputHandle, &input, 1, &numEventsRead))
+            abort();
+        if (input.EventType == KEY_EVENT && input.Event.KeyEvent.uChar.AsciiChar != 0 && input.Event.KeyEvent.bKeyDown)
+			return input.Event.KeyEvent.uChar.AsciiChar;
+    }
+}

--- a/src/sys/windows/uemacs.sln
+++ b/src/sys/windows/uemacs.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30711.63
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "uemacs", "uemacs.vcxproj", "{D39ED84D-20F2-4630-AB77-A00C52AFBC32}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D39ED84D-20F2-4630-AB77-A00C52AFBC32}.Debug|x64.ActiveCfg = Debug|x64
+		{D39ED84D-20F2-4630-AB77-A00C52AFBC32}.Debug|x64.Build.0 = Debug|x64
+		{D39ED84D-20F2-4630-AB77-A00C52AFBC32}.Debug|x86.ActiveCfg = Debug|Win32
+		{D39ED84D-20F2-4630-AB77-A00C52AFBC32}.Debug|x86.Build.0 = Debug|Win32
+		{D39ED84D-20F2-4630-AB77-A00C52AFBC32}.Release|x64.ActiveCfg = Release|x64
+		{D39ED84D-20F2-4630-AB77-A00C52AFBC32}.Release|x64.Build.0 = Release|x64
+		{D39ED84D-20F2-4630-AB77-A00C52AFBC32}.Release|x86.ActiveCfg = Release|Win32
+		{D39ED84D-20F2-4630-AB77-A00C52AFBC32}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {86D95F68-A830-461D-BFBF-CDA3B55EF360}
+	EndGlobalSection
+EndGlobal

--- a/src/sys/windows/uemacs.vcxproj
+++ b/src/sys/windows/uemacs.vcxproj
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{d39ed84d-20f2-4630-ab77-a00c52afbc32}</ProjectGuid>
+    <RootNamespace>CProj</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>$(ProjectDir).;$(ProjectDir)..\..;$(ProjectDir)..\..\tty\windows-console;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(ProjectDir).;$(ProjectDir)..\..;$(ProjectDir)..\..\tty\windows-console;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>$(ProjectDir).;$(ProjectDir)..\..;$(ProjectDir)..\..\tty\windows-console;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(ProjectDir).;$(ProjectDir)..\..;$(ProjectDir)..\..\tty\windows-console;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>false</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;HAVE_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <DisableSpecificWarnings>4716;4033;4013;4715;4101</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>false</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;HAVE_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <DisableSpecificWarnings>4716;4033;4013;4715;4101</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <DisableSpecificWarnings>4716;4033</DisableSpecificWarnings>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>false</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;HAVE_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <DisableSpecificWarnings>4716;4033;4013;4715;4101</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>false</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;HAVE_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <DisableSpecificWarnings>4716;4033;4013;4715;4101</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <!-- Files from src/sys/windows -->
+    <ClCompile Include="fileio.c" />
+    <ClCompile Include="spawn.c" />
+    <ClCompile Include="ttyio.c" />
+    <!-- Files from src/tty/windows-console -->
+    <ClCompile Include="..\..\tty\windows-console\tty.c" />
+    <ClCompile Include="..\..\tty\windows-console\ttykbd.c" />
+    <!-- Files from src -->
+    <ClCompile Include="..\..\main.c" />
+    <ClCompile Include="..\..\basic.c" />
+    <ClCompile Include="..\..\buffer.c" />
+    <ClCompile Include="..\..\cinfo.c" />
+    <ClCompile Include="..\..\display.c" />
+    <ClCompile Include="..\..\echo.c" />
+    <ClCompile Include="..\..\extend.c" />
+    <ClCompile Include="..\..\file.c" />
+    <ClCompile Include="..\..\kbd.c" />
+    <ClCompile Include="..\..\line.c" />
+    <ClCompile Include="..\..\random.c" />
+    <ClCompile Include="..\..\region.c" />
+    <ClCompile Include="..\..\search.c" />
+    <ClCompile Include="..\..\symbol.c" />
+    <ClCompile Include="..\..\version.c" />
+    <ClCompile Include="..\..\window.c" />
+    <ClCompile Include="..\..\word.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\def.h" />
+    <ClInclude Include="..\..\tty\windows-console\ttydef.h" />
+    <ClInclude Include="config.h" />
+    <ClInclude Include="sysdef.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/sys/windows/uemacs.vcxproj.filters
+++ b/src/sys/windows/uemacs.vcxproj.filters
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\src">
+      <UniqueIdentifier>{a022ebdc-89ea-454b-9f7a-6bb823e5250d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\sys">
+      <UniqueIdentifier>{734859fe-623f-4a71-bd22-f0eb464d33d5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\sys\windows">
+      <UniqueIdentifier>{76f0163f-7a0d-4595-9c7f-9fd2c2da1214}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\tty">
+      <UniqueIdentifier>{8c51c97e-cdd5-4467-a31c-643364171b5e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\src\tty\windows-console">
+      <UniqueIdentifier>{7d1b2075-be01-4c91-9303-fb9a476e103c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\src">
+      <UniqueIdentifier>{8399a27c-d5e5-4130-ab0d-c1649a472c99}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\src\windows">
+      <UniqueIdentifier>{4122c497-0416-4e52-93f2-62c14333bd71}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\src\tty">
+      <UniqueIdentifier>{85f03ad9-006e-48fc-9ad6-79410cf3556b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\src\tty\windows-console">
+      <UniqueIdentifier>{7b948921-21a2-4bc2-b9dd-22d2bf315320}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\file.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\extend.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\echo.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\display.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cinfo.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\buffer.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\basic.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="fileio.c">
+      <Filter>Source Files\src\sys\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\search.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\region.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\random.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\main.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\line.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\kbd.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="spawn.c">
+      <Filter>Source Files\src\sys\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\symbol.c">
+      <Filter>Source Files\src\sys\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\tty\windows-console\ttykbd.c">
+      <Filter>Source Files\src\tty\windows-console</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\tty\windows-console\tty.c">
+      <Filter>Source Files\src\tty\windows-console</Filter>
+    </ClCompile>
+    <ClCompile Include="ttyio.c">
+      <Filter>Source Files\src\sys\windows</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\word.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\version.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\window.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="config.h">
+      <Filter>Header Files\src\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="sysdef.h">
+      <Filter>Header Files\src\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\def.h">
+      <Filter>Header Files\src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\tty\windows-console\ttydef.h">
+      <Filter>Header Files\src\tty\windows-console</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/src/tty/windows-console/tty.c
+++ b/src/tty/windows-console/tty.c
@@ -1,0 +1,285 @@
+/*
+ * ANSI display driver. Based on the original ANSI source code by Dave Conroy.
+ *
+ * Jörgen Sigvardsson <jorgen.sigvardsson@gmail.com>
+ */
+#include	"def.h"
+
+#define	BEL	0x07			/* BEL character.		*/
+#define	ESC	0x1B			/* ESC character.		*/
+#define	LF	0x0A			/* Line feed.			*/
+
+extern	int	ttrow;
+extern	int	ttcol;
+extern	int	tttop;
+extern	int	ttbot;
+extern	int	tthue;
+
+int	tceeol	=	3;		/* Costs, ANSI display.		*/
+int	tcinsl	= 	17;
+int	tcdell	=	16;
+
+/*
+ * no-op
+ */
+ttinit()
+{
+}
+
+/*
+ * no-op
+ */
+tttidy()
+{
+}
+
+/*
+ * Move the cursor to the specified
+ * origin 0 row and column position. Try to
+ * optimize out extra moves; redisplay may
+ * have left the cursor in the right
+ * location last time!
+ */
+ttmove(row, col)
+{
+	if (ttrow!=row || ttcol!=col) {
+		ttputc(ESC);
+		ttputc('[');
+		asciiparm(row+1);
+		ttputc(';');
+		asciiparm(col+1);
+		ttputc('H');
+		ttrow = row;
+		ttcol = col;
+	}
+}
+
+/*
+ * Erase to end of line.
+ */
+tteeol()
+{
+	ttputc(ESC);
+	ttputc('[');
+	ttputc('K');
+}
+
+/*
+ * Erase to end of page.
+ */
+tteeop()
+{
+	ttputc(ESC);
+	ttputc('[');
+	ttputc('J');
+}
+
+/*
+ * Make a noise.
+ */
+ttbeep()
+{
+	ttputc(BEL);
+	ttflush();
+}
+
+/*
+ * Convert a number to decimal
+ * ascii, and write it out. Used to
+ * deal with numeric arguments.
+ */
+asciiparm(n)
+register int	n;
+{
+	register int	q;
+
+	q = n/10;
+	if (q != 0)
+		asciiparm(q);
+	ttputc((n%10) + '0');
+}
+
+/*
+ * Insert a block of blank lines onto the
+ * screen, using a scrolling region that starts at row
+ * "row" and extends down to row "bot". Deal with the one
+ * line case, which is a little bit special, with special
+ * case code. Put all of the back index commands out
+ * in a block. 
+ */
+ttinsl(row, bot, nchunk)
+{
+	if (row == bot) {			/* Funny case.		*/
+		if (nchunk != 1)
+			abort();
+		ttmove(row, 0);
+		tteeol();
+	} else {				/* General case.	*/
+		ttwindow(row, bot);
+		ttmove(row, 0);
+		while (nchunk--) {
+			ttputc(ESC);		/* Back index.		*/
+			ttputc('M');
+		}
+	}
+}
+
+/*
+ * Delete a block of lines, with the uppermost
+ * line at row "row", in a screen slice that extends to
+ * row "bot". The "nchunk" is the number of lines that have
+ * to be deleted. Watch for the pathalogical 1 line case,
+ * where the scroll region is *not* the way to do it.
+ * The block delete is used by the slightly more
+ * optimal display code.
+ */
+ttdell(row, bot, nchunk)
+{
+	if (row == bot) {			/* Funny case.		*/
+		if (nchunk != 1)
+			abort();
+		ttmove(row, 0);
+		tteeol();
+	} else {				/* General case.	*/
+		ttwindow(row, bot);
+		ttmove(bot, 0);
+		while (nchunk--)
+			ttputc(LF);
+	}
+}
+
+/*
+ * This routine sets the scrolling window
+ * on the display to go from line "top" to line
+ * "bot" (origin 0, inclusive). The caller checks
+ * for the pathalogical 1 line scroll window that
+ * doesn't work right, and avoids it. The "ttrow"
+ * and "ttcol" variables are set to a crazy value
+ * to ensure that the next call to "ttmove" does
+ * not turn into a no-op (the window adjustment
+ * moves the cursor).
+ */
+ttwindow(top, bot)
+{
+	if (tttop!=top || ttbot!=bot) {
+		ttputc(ESC);
+		ttputc('[');
+		asciiparm(top+1);
+		ttputc(';');
+		asciiparm(bot+1);
+		ttputc('r');
+		ttrow = HUGE;			/* Unknown.		*/
+		ttcol = HUGE;
+		tttop = top;			/* Remember region.	*/
+		ttbot = bot;
+	}
+}
+
+/*
+ * Switch to full screen scroll. This is
+ * used by "spawn.c" just before is suspends the
+ * editor, and by "display.c" when it is getting ready
+ * to exit. This function gets to full screen scroll
+ * by sending a DECSTBM with default parameters, but
+ * I think that this is wrong. The SRM seems to say
+ * that the default for Pb is 24, not the size of the
+ * screen, which seems really dumb. Do I really have
+ * to read the size of the screen as in "ttresize"
+ * to do this right?
+ */
+ttnowindow()
+{
+	ttputc(ESC);
+	ttputc('[');
+	ttputc(';');
+	ttputc('r');
+	ttrow = HUGE;				/* Unknown.		*/
+	ttcol = HUGE;
+	tttop = HUGE;				/* No scroll region.	*/
+	ttbot = HUGE;
+}
+
+/*
+ * Set the current writing color to the
+ * specified color. Watch for color changes that are
+ * not going to do anything (the color is already right)
+ * and don't send anything to the display.
+ * The rainbow version does this in putline.s on a
+ * line by line basis, so don't bother sending
+ * out the color shift.
+ */
+ttcolor(color)
+register int	color;
+{
+	if (color != tthue) {
+/*
+if	!RAINBOW
+*/
+		if (color == CTEXT) {		/* Normal video.	*/
+			ttputc(ESC);
+			ttputc('[');
+			ttputc('m');
+		} else if (color == CMODE) {	/* Reverse video.	*/
+			ttputc(ESC);
+			ttputc('[');
+			ttputc('7');
+			ttputc('m');
+		}
+/*
+endif
+*/
+		tthue = color;			/* Save the color.	*/
+	}
+}
+
+/*
+ * This routine is called by the
+ * "refresh the screen" command to try and resize
+ * the display. The new size, which must be deadstopped
+ * to not exceed the NROW and NCOL limits, it stored
+ * back into "nrow" and "ncol". Display can always deal
+ * with a screen NROW by NCOL. Look in "window.c" to
+ * see how the caller deals with a change.
+ */
+ttresize()
+{
+	register int	c;
+	register int	newnrow;
+	register int	newncol;
+
+	ttputc(ESC);				/* Off the end of the	*/
+	ttputc('[');				/* world. The terminal	*/
+	asciiparm(HUGE);			/* will chop it.	*/
+	ttputc(';');
+	asciiparm(HUGE);
+	ttputc('H');
+	ttrow = HUGE;				/* Unknown.		*/
+	ttcol = HUGE;
+	ttputc(ESC);				/* Report position.	*/
+	ttputc('[');
+	ttputc('6');
+	ttputc('n');
+	ttflush();
+	if (ttgetc()!=ESC || ttgetc()!='[')
+		return;
+	newnrow = 0;
+	while ((c=ttgetc())>='0' && c<='9')
+		newnrow = 10*newnrow + c - '0';
+	if (c != ';')
+		return;
+	newncol = 0;
+	while ((c=ttgetc())>='0' && c<='9')
+		newncol = 10*newncol + c - '0';
+	if (c != 'R')
+		return;
+	if (newnrow < 1)			/* Check limits.	*/
+		newnrow = 1;
+	else if (newnrow > NROW)
+		newnrow = NROW;
+	if (newncol < 1)
+		newncol = 1;
+	else if (newncol > NCOL)
+		newncol = NCOL;
+	nrow = newnrow;
+	ncol = newncol;
+}

--- a/src/tty/windows-console/ttydef.h
+++ b/src/tty/windows-console/ttydef.h
@@ -1,0 +1,58 @@
+/*
+ * Name:	MicroEMACS
+ *		Digital ANSI terminal header file
+ * Version:	29
+ * Last edit:	05-Feb-86
+ * By:		rex::conroy
+ *		decvax!decwrl!dec-rhea!dec-rex!conroy
+ */
+#define	GOSLING	1			/* Compile in fancy display.	*/
+#define	MEMMAP	0			/* Not memory mapped video.	*/
+
+/*
+ * Yes Bob, it's wrong for you.
+ */
+#define	NROW	50			/* Rows.			*/
+#define	NCOL	132			/* Columns.			*/
+
+/*
+ * Special keys, as on the LK201, which is
+ * a superset of the VT100. Originally I tried to keep the
+ * numbers in LK201 escape sequence code, but it became too much
+ * of a pain because of the keycodes greater than 31. 
+ * The codes are all just redefinitions for the standard extra
+ * key codes. Using the standard names ensures that the
+ * LK201 codes land in the right place.
+ *
+ * Added keys for Windows/PC.
+ */
+#define	KUP	K01
+#define	KDOWN	K02
+#define	KLEFT	K03
+#define	KRIGHT	K04
+#define	KFIND	K05
+#define	KINSERT	K06
+#define	KREMOVE	K07
+#define	KSELECT	K08
+#define	KPREV	K09
+#define	KNEXT	K0A
+#define	KF4	K0B
+#define	KF6	K0C
+#define	KF7	K0D
+#define	KF8	K0E
+#define	KF9	K0F
+#define	KF10	K10
+#define	KF11	K11
+#define	KF12	K12
+#define	KF13	K13
+#define	KF14	K14
+#define	KHELP	K15
+#define	KDO	K16
+#define	KF17	K17
+#define	KF18	K18
+#define	KF19	K19
+#define	KF20	K1A
+#define	KPF1	K1B
+#define	KPF2	K1C
+#define	KPF3	K1D
+#define	KPF4	K1E

--- a/src/tty/windows-console/ttykbd.c
+++ b/src/tty/windows-console/ttykbd.c
@@ -1,0 +1,174 @@
+/*
+ * ANSI input driver. Based on the original ANSI source code by Dave Conroy.
+ *
+ * Jörgen Sigvardsson <jorgen.sigvardsson@gmail.com>
+ */
+#include	"def.h"
+
+#define	ESC	0x1B			/* Escape, arrows et al.	*/
+#define	AGRAVE	0x60			/* LK201 kludge.		*/
+
+/*
+ * The special keys on an LK201 send back
+ * escape sequences of the general form <ESC>[nnn~, where
+ * nnn is a key code number. This table is indexed by the
+ * nnn code to get the key code, which is used in the
+ * binding table. The F4 key, and the F6 through F14 keys
+ * have key codes. Also F17 through F20. Think of
+ * help and do as special.
+ */
+short	lk201map[] = {
+	KRANDOM,	KFIND,		KINSERT,	KREMOVE,
+	KSELECT,	KPREV,		KNEXT,		KRANDOM,
+	KRANDOM,	KRANDOM,	KRANDOM,	KRANDOM,
+	KRANDOM,	KRANDOM,	KF4,		KRANDOM,
+	KRANDOM,	KF6,		KF7,		KF8,
+	KF9,		KF10,		KRANDOM,	KF11,
+	KF12,		KF13,		KF14,		KRANDOM,
+	KHELP,		KDO,		KRANDOM,	KF17,
+	KF18,		KF19,		KF20
+};
+
+/*
+ * Names for the keys with basic keycode
+ * between KFIRST and KLAST (inclusive). This is used by
+ * the key name routine in "kbd.c".
+ */
+char	*keystrings[] = {
+	NULL,		"Up",		"Down",		"Left",
+	"Right",	"Find",		"Insert",	"Remove",
+	"Select",	"Previous",	"Next",		"F4",
+	"F6",		"F7",		"F8",		"F9",
+	"F10",		"F11",		"F12",		"F13",
+	"F14",		"Help",		"Do",		"F17",
+	"F18",		"F19",		"F20",		"PF1",
+	"PF2",		"PF3",		"PF4",		NULL
+};
+
+/*
+ * Read in a key, doing the low level mapping
+ * of ASCII code to 11 bit code. This level deals with
+ * mapping the special keys into their spots in the C1
+ * control area. The C0 controls go right through, and
+ * get remapped by "getkey".
+ */
+getkbd()
+{
+	register int	c;
+	register int	n;
+loop:
+	c = ttgetc();
+	if (c == AGRAVE)			/* On LK201, grave is	*/
+		c = METACH;			/* also META.		*/
+	if (c == ESC) {
+		c = ttgetc();
+		if (c == '[') {
+			c = ttgetc();
+			if (c == 'A')
+				return (KUP);
+			if (c == 'B')
+				return (KDOWN);
+			if (c == 'C')
+				return (KRIGHT);
+			if (c == 'D')
+				return (KLEFT);
+			if (c == 'F') /* Maps to the "End" key on PC/Windows */
+				return KSELECT;
+			if (c == 'H') /* Maps to the "Home" key on PC/Windows */
+				return KFIND;
+			if (c>='0' && c<='9') {	/* LK201 functions.	*/
+				n = 0;
+				do {
+					n = 10*n + c - '0';
+					c = ttgetc();
+				} while (c>='0' && c<='9');
+				if (c=='~' && n<=34) {
+					c = lk201map[n];
+					if (c != KRANDOM)
+						return (c);
+					goto loop;
+				}
+			}
+			goto loop;
+		}
+		if (c == 'O') {	
+			c = ttgetc();
+			if (c == 'A')
+				return (KUP);
+			if (c == 'B')
+				return (KDOWN);
+			if (c == 'C')
+				return (KRIGHT);
+			if (c == 'D')
+				return (KLEFT);
+			if (c == 'P')
+				return (KHELP); /* Maps to F1 on Windows/PC */
+			if (c == 'Q')
+				return (KPF2);
+			if (c == 'R')
+				return (KPF3);
+			if (c == 'S')
+				return (KPF4);
+			goto loop;
+		}
+		if (ISLOWER(c) != FALSE)	/* Copy the standard	*/
+			c = TOUPPER(c);		/* META code.		*/
+		if (c>=0x00 && c<=0x1F)
+			c = KCTRL | (c+'@');
+		return (KMETA | c);
+	}
+
+	return (c);
+}
+
+/*
+ * Terminal specific keymap initialization.
+ * Attach the special keys to the appropriate built
+ * in functions. Bind all of the assigned graphics in the
+ * DEC supplimental character set to "ins-self".
+ * As is the case of all the keymap routines, errors
+ * are very fatal.
+ */
+ttykeymapinit()
+{
+	register SYMBOL	*sp;
+	register int	i;
+
+	keydup(KFIND,	"search-again");
+	keydup(KHELP,	"help");
+	keydup(KPF2,    "display-bindings");
+	keydup(KINSERT, "yank");
+	keydup(KREMOVE, "kill-region");
+	keydup(KSELECT, "set-mark");
+	keydup(KPREV,	"back-page");
+	keydup(KNEXT,	"forw-page");
+	keydup(KDO,	"execute-macro");
+	keydup(KF17,	"back-window");
+	keydup(KF18,	"forw-window");
+	keydup(KF19,	"enlarge-window");
+	keydup(KF20,	"shrink-window");
+	keydup(KUP,	"back-line");
+	keydup(KDOWN,	"forw-line");
+	keydup(KRIGHT,	"forw-char");
+	keydup(KLEFT,	"back-char");
+
+	/*
+	 * Bind all GR positions that correspond
+	 * to assigned characters in the Digital multinational
+	 * character set to "ins-self". These characters may
+	 * be used just like any other character.
+	 */
+
+	if ((sp=symlookup("ins-self")) == NULL)
+		abort();
+	for (i=0xA0; i<0xFF; ++i) {
+		if (i!=0xA4 && i!=0xA6 && i!=0xAC && i!=0xAD && i!=0xAE
+		&&  i!=0xAF && i!=0xB4 && i!=0xB8 && i!=0xBE && i!=0xF0
+		&&  i!=0xFE && i!=0xA0) {
+			if (binding[i] != NULL)
+				abort();
+			binding[i] = sp;
+			++sp->s_nkey;
+		}
+	}
+}


### PR DESCRIPTION
The Windows port is now fairly complete. Keymaps might not be complete, as I don't know all functionality of the editor to test them.

It seems that the old code base is working under the assumption that terminals are of fixed size. There are compile time constants `NROW`, and `NCOL` which necessarily don't match the runtime variables `nrow` and `ncol`. The Windows port will use 
 the compile time constants, and initialize the runtime variables with corresponding values, and then resize the terminal to match those values. This way screen updates will be correct. The other option would be to change the `NROW` and `NCOL` compile time constants into runtime variables, but that would alter the original source profoundly which is not desirable.

The shell spawn works much like the UNIX counterpart. The main difference between UNIX and Windows is that there is no "user selected shell". Instead, there's a system shell, and that's it. I have added the possibility for the user to override this with for example powershell, and that is done with the environment variable `UEMACS_SHELL`. If that variable does not exist, then uemacs will check if the system shell is set (`ComSpec` environment variable). If that's not defined, then it'll shoot from the hip and execute `cmd.exe`.

Fixes #5 