### PR TITLE
Name correction

### DIFF
--- a/.github/workflows/uemacs.yml
+++ b/.github/workflows/uemacs.yml
@@ -1,0 +1,10 @@
+name: learn-github-actions
+on: [push]
+jobs:
+  build-with-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          push: false        

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM gcc:10 as build
+
+WORKDIR /build
+
+# Grab dependencies
+COPY UNLICENSE .
+COPY README.md .
+COPY autogen.sh .
+COPY configure.ac .
+COPY Makefile.am .
+COPY ./src/ ./src
+
+# Configure source
+RUN ./autogen.sh
+RUN yes '' | ./configure # Say yes to everything!
+
+# Use as many cores as possible. Not that it's needed, but why the hell not?
+RUN make -j$(lscpu | grep -E "^CPU\(s\):" | awk '{ print $2 }')
+RUN strip /build/src/uemacs
+
+# And finally the runtime image
+FROM debian:buster-slim
+WORKDIR /usr/local/bin
+
+COPY --from=build /build/src/uemacs /usr/local/bin/uemacs
+
+CMD /usr/local/bin/uemacs

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Run `./autogen.sh` when checking out the sources from GIT to create the
 Porting Notes
 -------------
 
-This port to was made by Joachim Wiberg (UNIX) and Jörgen Sigwardsson
+This port to was made by Joachim Wiberg (UNIX) and Jörgen Sigvardsson
 (Windows).  Other ports or bug fixes are most welcome, as long as they
 stay in the spirit of the original MicroEMACS.
 


### PR DESCRIPTION
A Dockerfile that builds `uemacs` using `gcc:10` (as of this date based on Debian buster), and a github workflow to verify the build on each push. The build artifact (`uemacs` executable) is then copied to a `debian:buster-slim` base image that runs `CMD /usr/local/bin/uemacs`. The runtime image is not executed as part of the build verification, although that could be a nice smoke test.